### PR TITLE
fix linux build and mesa issues

### DIFF
--- a/cadscenefile.cpp
+++ b/cadscenefile.cpp
@@ -76,16 +76,16 @@ struct CSFileMemory_s
   }
 };
 
-CSFAPI CSFileMemoryPTR CSFileMemory_new()
+NV_API_EXPORT CSFileMemoryPTR CSFileMemory_new()
 {
   return new CSFileMemory_s;
 }
-CSFAPI void CSFileMemory_delete(CSFileMemoryPTR mem)
+NV_API_EXPORT void CSFileMemory_delete(CSFileMemoryPTR mem)
 {
   delete mem;
 }
 
-CSFAPI void* CSFileMemory_alloc(CSFileMemoryPTR mem, size_t sz, const void*fill)
+NV_API_EXPORT void* CSFileMemory_alloc(CSFileMemoryPTR mem, size_t sz, const void*fill)
 {
   return mem->alloc(sz,fill);
 }
@@ -97,7 +97,7 @@ static size_t CSFile_getRawSize(CSFile* csf)
   return csf->pointersOFFSET + csf->numPointers * sizeof(CSFoffset);
 }
 
-CSFAPI int     CSFile_loadRaw (CSFile** outcsf, size_t size, void* dataraw)
+NV_API_EXPORT int     CSFile_loadRaw (CSFile** outcsf, size_t size, void* dataraw)
 {
   char* data  = (char*)dataraw;
   CSFile* csf = (CSFile*)data;
@@ -136,7 +136,7 @@ CSFAPI int     CSFile_loadRaw (CSFile** outcsf, size_t size, void* dataraw)
   return CADSCENEFILE_NOERROR;
 }
 
-CSFAPI int CSFile_load(CSFile** outcsf, const char* filename, CSFileMemoryPTR mem)
+NV_API_EXPORT int CSFile_load(CSFile** outcsf, const char* filename, CSFileMemoryPTR mem)
 {
   FILE* file;
 #ifdef WIN32
@@ -178,7 +178,7 @@ CSFAPI int CSFile_load(CSFile** outcsf, const char* filename, CSFileMemoryPTR me
 }
 
 #if CSF_ZIP_SUPPORT
-CSFAPI int CSFile_loadExt(CSFile** outcsf, const char* filename, CSFileMemoryPTR mem)
+NV_API_EXPORT int CSFile_loadExt(CSFile** outcsf, const char* filename, CSFileMemoryPTR mem)
 {
   size_t len = strlen(filename);
   if (strcmp(filename+len-3,".gz")==0) {
@@ -481,13 +481,13 @@ static int CSFile_saveInternal(const CSFile* csf, const char* filename, CSFileMe
   return CADSCENEFILE_NOERROR;
 }
 
-CSFAPI int CSFile_save(const CSFile* csf, const char* filename)
+NV_API_EXPORT int CSFile_save(const CSFile* csf, const char* filename)
 {
   return CSFile_saveInternal<OutputFILE>(csf,filename,0);
 }
 
 #if CSF_ZIP_SUPPORT
-CSFAPI int CSFile_saveExt(CSFile* csf, const char* filename)
+NV_API_EXPORT int CSFile_saveExt(CSFile* csf, const char* filename)
 {
   size_t len = strlen(filename);
   if (strcmp(filename+len-3,".gz")==0) {
@@ -545,7 +545,7 @@ static void CSFile_transformHierarchy(CSFile *csf, CSFNode * NV_RESTRICT node, C
   }
 }
 
-CSFAPI int CSFile_transform( CSFile *csf )
+NV_API_EXPORT int CSFile_transform( CSFile *csf )
 {
   if (!(csf->fileFlags & CADSCENEFILE_FLAG_UNIQUENODES))
     return CADSCENEFILE_ERROR_OPERATION;

--- a/cadscenefile.h
+++ b/cadscenefile.h
@@ -26,11 +26,9 @@
 
 #pragma once
 
+#include "platform.h"
 
-extern "C" {
-
-#define CSFAPI __declspec(dllexport)
-
+extern "C" {   
   enum {
     CADSCENEFILE_VERSION = 4,
     CADSCENEFILE_VERSION_COMPAT = 2,
@@ -172,19 +170,19 @@ extern "C" {
 
   typedef struct CSFileMemory_s* CSFileMemoryPTR;
 
-  CSFAPI CSFileMemoryPTR CSFileMemory_new();
-  CSFAPI void*  CSFileMemory_alloc(CSFileMemoryPTR mem, size_t sz, const void*fill);
-  CSFAPI void   CSFileMemory_delete(CSFileMemoryPTR mem);
+  NV_API_EXPORT CSFileMemoryPTR CSFileMemory_new();
+  NV_API_EXPORT void*  CSFileMemory_alloc(CSFileMemoryPTR mem, size_t sz, const void*fill);
+  NV_API_EXPORT void   CSFileMemory_delete(CSFileMemoryPTR mem);
 
-  CSFAPI int    CSFile_loadRaw (CSFile** outcsf, size_t sz, void* data);
-  CSFAPI int    CSFile_load    (CSFile** outcsf, const char* filename, CSFileMemoryPTR mem);
-  CSFAPI int    CSFile_save    (const CSFile* csf, const char* filename);
+  NV_API_EXPORT int    CSFile_loadRaw (CSFile** outcsf, size_t sz, void* data);
+  NV_API_EXPORT int    CSFile_load    (CSFile** outcsf, const char* filename, CSFileMemoryPTR mem);
+  NV_API_EXPORT int    CSFile_save    (const CSFile* csf, const char* filename);
 
-  CSFAPI int    CSFile_transform(CSFile *csf);  // requires unique nodes
+  NV_API_EXPORT int    CSFile_transform(CSFile *csf);  // requires unique nodes
 
 #if CSF_ZIP_SUPPORT
-  CSFAPI int    CSFile_loadExt(CSFile** outcsf, const char* filename, CSFileMemoryPTR mem);
-  CSFAPI int    CSFile_saveExt(CSFile* csf, const char* filename);
+  NV_API_EXPORT int    CSFile_loadExt(CSFile** outcsf, const char* filename, CSFileMemoryPTR mem);
+  NV_API_EXPORT int    CSFile_saveExt(CSFile* csf, const char* filename);
 #endif
 
 };

--- a/common.h
+++ b/common.h
@@ -41,7 +41,6 @@ struct SceneData {
 
 #if defined(GL_core_profile) || defined(GL_compatibility_profile) || defined(GL_es_profile)
 
-#extension GL_NV_command_list : enable
 #if GL_NV_command_list
 layout(commandBindableNV) uniform;
 #endif
@@ -60,8 +59,6 @@ layout(std140,binding=UBO_MATRIX) uniform matrixBuffer {
   mat4 objectMatrixIT;
 } object;
 
-#extension GL_ARB_bindless_texture : enable
-#extension GL_NV_bindless_texture : enable
 #if GL_NV_bindless_texture
 #define matricesBuffer  samplerBuffer(scene.tboMatrices)
 #else

--- a/cull-bitpack.vert.glsl
+++ b/cull-bitpack.vert.glsl
@@ -1,4 +1,6 @@
 #version 330
+#extension GL_ARB_explicit_attrib_location : require
+#extension GL_ARB_shader_storage_buffer_object : enable
 /**/
 
 #define TEMPORAL_LAST 1
@@ -7,9 +9,6 @@
 #ifndef TEMPORAL
 #define TEMPORAL 0
 #endif
-
-#extension GL_ARB_explicit_attrib_location : require
-#extension GL_ARB_shader_storage_buffer_object : enable
 
 layout(location=0) in uvec4 instream[8];
 

--- a/cull-xfb.vert.glsl
+++ b/cull-xfb.vert.glsl
@@ -1,4 +1,6 @@
 #version 330
+#extension GL_ARB_explicit_attrib_location : require
+#extension GL_ARB_shader_storage_buffer_object : enable
 /**/
 
 #ifndef MATRIX_WORLD
@@ -12,10 +14,6 @@
 #ifndef MATRICES
 #define MATRICES        2
 #endif
-
-#extension GL_ARB_explicit_attrib_location : require
-#extension GL_ARB_shader_storage_buffer_object : enable
-
 
 //#define OCCLUSION
 

--- a/nodetree.cpp
+++ b/nodetree.cpp
@@ -56,7 +56,7 @@ const NodeTree::Level* NodeTree::getUsedLevel( int level ) const
   if (0 <= level && level < m_levelsUsed){
     return &m_levels[level];
   }
-  return NULL;
+  return 0;
 }
 
 unsigned int NodeTree::getTreeParentIncarnation() const

--- a/nvtoken.cpp
+++ b/nvtoken.cpp
@@ -164,7 +164,7 @@ namespace nvtoken
 
   // Emulation related
 
-  static __forceinline GLenum nvtokenDrawCommandSequenceSW( const void* NVP_RESTRICT stream, size_t streamSize, GLenum mode, GLenum type, const StateSystem::State& state ) 
+  static NV_FORCE_INLINE GLenum nvtokenDrawCommandSequenceSW( const void* NVP_RESTRICT stream, size_t streamSize, GLenum mode, GLenum type, const StateSystem::State& state ) 
   {
     const GLubyte* NVP_RESTRICT current = (GLubyte*)stream;
     const GLubyte* streamEnd = current + streamSize;

--- a/scan.comp.glsl
+++ b/scan.comp.glsl
@@ -1,4 +1,6 @@
 #version 430
+#extension GL_NV_shader_thread_group : enable
+#extension GL_NV_shader_thread_shuffle : enable
 /**/
 
 #define TASK_SUM      0
@@ -23,9 +25,6 @@ layout (local_size_x = THREADBLOCK_SIZE) in;
 #if TASK != TASK_COMBINE
 
 uint threadIdx = gl_LocalInvocationID.x;
-
-#extension GL_NV_shader_thread_group : enable
-#extension GL_NV_shader_thread_shuffle : enable
 
 #if GL_NV_shader_thread_group
 

--- a/scene.frag.glsl
+++ b/scene.frag.glsl
@@ -1,7 +1,10 @@
 #version 430
+#extension GL_ARB_shading_language_include : enable
+#extension GL_NV_command_list : enable
+#extension GL_ARB_bindless_texture : enable
+#extension GL_NV_bindless_texture : enable
 /**/
 
-#extension GL_ARB_shading_language_include : enable
 #include "common.h"
 
 // must match cadscene

--- a/scene.vert.glsl
+++ b/scene.vert.glsl
@@ -1,7 +1,10 @@
 #version 430
+#extension GL_ARB_shading_language_include : enable
+#extension GL_NV_command_list : enable
+#extension GL_ARB_bindless_texture : enable
+#extension GL_NV_bindless_texture : enable
 /**/
 
-#extension GL_ARB_shading_language_include : enable
 #include "common.h"
 
 #if USE_INDEXING && USE_BASEINSTANCE

--- a/statesystem.cpp
+++ b/statesystem.cpp
@@ -720,7 +720,7 @@ const StateSystem::State& StateSystem::get( StateID id ) const
   return m_states[id].state;
 }
 
-__forceinline int StateSystem::prepareTransitionCache(StateID prev, StateInternal& to )
+NV_FORCE_INLINE int StateSystem::prepareTransitionCache(StateID prev, StateInternal& to )
 {
   StateInternal& from = m_states[prev];
 

--- a/statesystem.hpp
+++ b/statesystem.hpp
@@ -31,6 +31,7 @@
 #include "platform.h"
 #include <GL/glew.h>
 #include <vector>
+#include <cstring>
 
 class StateSystem {
 public:

--- a/statesystem.hpp
+++ b/statesystem.hpp
@@ -28,7 +28,7 @@
 #ifndef STATESYSTEM_H__
 #define STATESYSTEM_H__
 
-
+#include "platform.h"
 #include <GL/glew.h>
 #include <vector>
 

--- a/transform-leaves.comp.glsl
+++ b/transform-leaves.comp.glsl
@@ -59,11 +59,11 @@ mat4 getMatrix(samplerBuffer texbuffer, int idx)
 
 mat4 getObjectMatrix(int idx, int what){
   return getMatrix(texObjectMatrices,idx*MATRICES + what + MATRIX_BEGIN_OBJECT);
-};
+}
 
 mat4 getWorldMatrix(int idx, int what){
   return getMatrix(texWorldMatrices,idx*MATRICES + what + MATRIX_BEGIN_WORLD);
-};
+}
 
 void main()
 {

--- a/transform-level.comp.glsl
+++ b/transform-level.comp.glsl
@@ -53,11 +53,11 @@ mat4 getMatrix(samplerBuffer texbuffer, int idx)
 
 mat4 getObjectMatrix(int idx, int what){
   return getMatrix(texObjectMatrices,idx*MATRICES + what + MATRIX_BEGIN_OBJECT);
-};
+}
 
 mat4 getWorldMatrix(int idx, int what){
   return getMatrix(texWorldMatrices,idx*MATRICES + what + MATRIX_BEGIN_WORLD);
-};
+}
 
 
 void main()

--- a/xplode-animation.comp.glsl
+++ b/xplode-animation.comp.glsl
@@ -45,11 +45,11 @@ mat4 getMatrix(samplerBuffer texbuffer, int idx)
 
 mat4 getObjectMatrixOrig(int idx, int what){
   return getMatrix(texMatricesOrig,idx*MATRICES + what + MATRIX_BEGIN_OBJECT);
-};
+}
 
 mat4 getWorldMatrixOrig(int idx, int what){
   return getMatrix(texMatricesOrig,idx*MATRICES + what + MATRIX_BEGIN_WORLD);
-};
+}
 
 void main()
 {


### PR DESCRIPTION
I've tested this on intel mesa drivers. 

I do still get the X error glxbadfbconfig because of the COMPATIBILITY PROFILE context flag at  https://github.com/CapsAdmin/shared_sources/blob/master/main_x11.cpp#L234 but I'm not sure what the solution is here. If I create the context with the CORE flag it works.

the NV_API_EXPORT definition comes from shared_resources PR

According to mesa extensions cannot be required in the middle of the code like the `#version` directive. This is sort of inconvenient with the `#include` but this is the only way to work around that properly. I've been told you can set the environment variable `allow_glsl_extension_directive_midshader=1` to make mesa workaround this issue before launching.
